### PR TITLE
Migrate from blaze-builder to bytestring's Builder.

### DIFF
--- a/benchmarks/Benchmark.hs
+++ b/benchmarks/Benchmark.hs
@@ -11,7 +11,7 @@
 -----------------------------------------------------------------------------
 module Main where
 
-import qualified Blaze.ByteString.Builder             as Blaze
+import qualified Data.ByteString.Builder              as BB
 import           Control.Applicative                  ((<$>))
 import qualified Control.Monad                        as CM
 import           Criterion.Main
@@ -34,7 +34,7 @@ benchmark :: IO ()
 benchmark = defaultMain [
     env (setupEnv 1000000) $ \ ~rows ->
         bgroup "IPC" [
-            bench "asyncIPC" $ nf (map (Blaze.toByteString . IPC.asyncIPC)) rows
+            bench "asyncIPC" $ nf (map (BB.bytestring . IPC.asyncIPC)) rows
         ]
    ]
 

--- a/kdb-haskell.cabal
+++ b/kdb-haskell.cabal
@@ -39,7 +39,7 @@ library
   default-language:   Haskell2010
   build-depends:      base >= 4 && < 5, transformers
                     , deepseq
-                    , network, io-streams, exceptions, blaze-builder, attoparsec
+                    , network, io-streams, exceptions, attoparsec
                     , cpu
                     , time
                     , bytestring
@@ -61,7 +61,7 @@ test-suite kdb-haskell-tests
   type:               exitcode-stdio-1.0
   build-depends:      base >= 4 && < 5, transformers
                     , deepseq
-                    , network, io-streams, exceptions, blaze-builder, attoparsec
+                    , network, io-streams, exceptions, attoparsec
                     , cpu
                     , time
                     , bytestring
@@ -96,7 +96,7 @@ benchmark kdb-haskell-benchmark
   main-is:            Benchmark.hs
   build-depends:      base >= 4 && < 5, transformers
                     , deepseq
-                    , network, io-streams, exceptions, blaze-builder, attoparsec
+                    , network, io-streams, exceptions, attoparsec
                     , cpu
                     , time
                     , bytestring

--- a/src/Database/Kdb/Internal/Client.hs
+++ b/src/Database/Kdb/Internal/Client.hs
@@ -26,9 +26,9 @@ module Database.Kdb.Internal.Client (
   )
   where
 
-import           Blaze.ByteString.Builder                 (Builder)
-import qualified Blaze.ByteString.Builder                 as Blaze
-import qualified Blaze.ByteString.Builder.Internal.Buffer as Blaze
+import           Data.ByteString.Builder                  (Builder)
+import qualified Data.ByteString.Builder.Extra            as BB
+import qualified Data.ByteString.Builder.Internal         as BB
 import           Control.Lens
 import           Control.Monad.Catch                      (MonadCatch,
                                                            MonadMask)
@@ -75,7 +75,7 @@ connect cs@ConnectionSettings {..} =
       (is, osNaked)
           <- Streams.socketToStreamsWithBufferSize _receiveBufferSize
                                                    socket
-      os <- Streams.unsafeBuilderStream (Blaze.allocBuffer _writeBufferSize) osNaked
+      os <- Streams.unsafeBuilderStream (BB.newBuffer _writeBufferSize) osNaked
 
       -- Write the login bytes
       writeAndFlush (loginBytesFromConnectionSettings cs) os
@@ -195,4 +195,4 @@ firstOrException _  (ea:eas) = ea >>= \e -> case e of
 writeAndFlush :: Builder -> Streams.OutputStream Builder -> IO ()
 writeAndFlush b os = do
   Streams.write (Just b)           os
-  Streams.write (Just Blaze.flush) os
+  Streams.write (Just BB.flush) os

--- a/src/Database/Kdb/Internal/Types/ClientTypes.hs
+++ b/src/Database/Kdb/Internal/Types/ClientTypes.hs
@@ -31,7 +31,7 @@ module Database.Kdb.Internal.Types.ClientTypes (
   , InvalidCredentials(..)
   ) where
 
-import           Blaze.ByteString.Builder  (Builder)
+import           Data.ByteString.Builder   (Builder)
 import           Control.Lens
 import           Control.Monad.Catch       (Exception)
 import           Data.ByteString           (ByteString)

--- a/tests/Database/Kdb/Internal/IPCTest.hs
+++ b/tests/Database/Kdb/Internal/IPCTest.hs
@@ -11,7 +11,7 @@
 -----------------------------------------------------------------------------
 module Database.Kdb.Internal.IPCTest (tests) where
 
-import qualified Blaze.ByteString.Builder as Blaze
+import qualified Data.ByteString.Builder as BB
 import           Control.Applicative      ((<$>), (<*))
 import           Control.DeepSeq          (deepseq)
 import qualified Data.Attoparsec          as A
@@ -57,7 +57,7 @@ testCases f = f <$> t
 
 serializationTest :: SimpleTestCase -> TestTree
 serializationTest (msg, actual, expected) = testCase msg $ do
-        let actualIPC    = Blaze.toByteString $ Kdb.asyncIPC actual
+        let actualIPC    = BB.bytestring $ Kdb.asyncIPC actual
             msg' = unlines [
                 msg
               , "   actual  =" ++ (unpack . encode $ actualIPC)


### PR DESCRIPTION
io-streams-3.0.0 switched from blaze-builder to bytestring's new Builder, so to make kdb-haskell build with it, this patch was required.
